### PR TITLE
Update build.zig for new Build API changes, link required libraries on Windows, and support building as a shared library

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ In summary:
 * Instrument the code using the provided Zig module
 * Use Tracy UI/server to connect to the instrumented Zig application and explore the profiler data
 
+## Building as a Shared Library
+
+If your project needs to call tracy functions from multiple DLLs, then you need to build the tracy client as a shared library.
+
+This is accomplished by passing the `shared` option, and (if you're using Windows) installing the resulting shared library next to your exe.
+
+```zig
+    const tracy = b.dependency("tracy", .{
+        .target = target,
+        .optimize = optimize,
+        .shared = true,
+    });
+
+    const install_dir = std.Build.Step.InstallArtifact.Options.Dir{ .override = .{ .bin = {} } };
+    const install_tracy = b.addInstallArtifact(tracy.artifact("tracy"), .{
+        .dest_dir = install_dir,
+        .pdb_dir = install_dir,
+    });
+    b.getInstallStep().dependOn(&install_tracy.step);
+```
+
+For additional context, see section 2.1.5 of the Tracy manual, "Setup for multi-DLL projects".
+
 ## Todo / Ideas
 
 * Figure out why system sampling is broken

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const options = @import("tracy-options");
 const c = @cImport({
     if (options.tracy_enable) @cDefine("TRACY_ENABLE", {});
@@ -22,6 +23,7 @@ const c = @cImport({
     if (options.tracy_fibers) @cDefine("TRACY_FIBERS", {});
     if (options.tracy_no_crash_handler) @cDefine("TRACY_NO_CRASH_HANDLER", {});
     if (options.tracy_timer_fallback) @cDefine("TRACY_TIMER_FALLBACK", {});
+    if (options.shared and builtin.os.tag == .windows) @cDefine("TRACY_IMPORTS", {});
 
     @cInclude("tracy/TracyC.h");
 });


### PR DESCRIPTION
First of all, thanks for this library!

I made a few changes to get this working with the latest zig version (0.12.0-dev.2795+dd4d320eb), and to get it compiling on Windows. My project uses an engine exe and a game dll, so I also added support for building tracy as a shared library.

- Update build.zig for new Build API changes
- Link libraries required on Windows
- Add support for building as a shared library
- Remove unused tracy_version