### PR TITLE
Build fixes for Zig 0.13

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -55,7 +55,7 @@ pub fn build(b: *std.Build) void {
     const tracy_src = b.dependency("tracy_src", .{});
 
     const tracy_module = b.addModule("tracy", .{
-        .root_source_file = .{ .path = "./src/tracy.zig" },
+        .root_source_file = b.path("./src/tracy.zig"),
         .imports = &.{
             .{
                 .name = "tracy-options",
@@ -83,7 +83,7 @@ pub fn build(b: *std.Build) void {
     tracy_client.linkLibCpp();
     tracy_client.addCSourceFile(.{
         .file = tracy_src.path("./public/TracyClient.cpp"),
-        .flags = &.{},
+        .flags = if (target.result.os.tag == .windows) &.{"-fms-extensions"} else &.{},
     });
     inline for (tracy_header_files) |header| {
         tracy_client.installHeader(


### PR DESCRIPTION
build: New build API changes for paths
build: Add `-fms-extensions` when compiling on Windows - this fixes a compile error where `__cpuidex` is not found

See: https://github.com/llvm/llvm-project/commit/f3baf63d9a1ba91974f4df6abb8f2abd9a0df5b5
