### PR TITLE
update Tracy dependency to v0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Easy to use bindings for the tracy client C API.
 ## Dependencies
 
 * Zig 0.14.1
-* Tracy 0.12.2 (only for viewing the profiling session, this repository is only concerned with client matters)
+* Tracy 0.13.0 (only for viewing the profiling session, this repository is only concerned with client matters)
 
 ## Features
 

--- a/build.zig
+++ b/build.zig
@@ -142,6 +142,7 @@ pub fn build(b: *std.Build) void {
 const tracy_header_files = [_][]const u8{
     "tracy/TracyC.h",
     "tracy/Tracy.hpp",
+    "tracy/TracyCUDA.hpp",
     "tracy/TracyD3D11.hpp",
     "tracy/TracyD3D12.hpp",
     "tracy/TracyLua.hpp",
@@ -181,8 +182,8 @@ const tracy_header_files = [_][]const u8{
     "common/TracySocket.hpp",
     "common/TracyStackFrames.hpp",
     "common/TracySystem.hpp",
-    "common/TracyUwp.hpp",
     "common/TracyVersion.hpp",
+    "common/TracyWinFamily.hpp",
     "common/TracyYield.hpp",
     "common/tracy_lz4.hpp",
     "common/tracy_lz4hc.hpp",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
     },
     .dependencies = .{
         .tracy_src = .{
-            .url = "https://github.com/wolfpld/tracy/archive/refs/tags/v0.12.2.tar.gz",
-            .hash = "N-V-__8AANptPwE8EYOS5w6KRzVyfllpOBthYRcuuQvYhhxb",
+            .url = "https://github.com/wolfpld/tracy/archive/refs/tags/v0.13.0.tar.gz",
+            .hash = "N-V-__8AAHW7KwHH_eNEviRWLkRfsxpWFrdOYM9f8VeCin4q",
         },
     },
 }


### PR DESCRIPTION
- Bump Tracy source archive to v0.13.0 in build.zig.zon and wire the version into build.zig.
- Document the new Tracy version in README.md.
