### PR TITLE
chore: Update Zig to 0.15.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zig_tracy,
     .fingerprint = 0x1c9150cfb12ae268,
     .version = "0.0.5",
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.2",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/example/build.zig
+++ b/example/build.zig
@@ -15,9 +15,11 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "tracy-example",
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     exe.root_module.addImport("tracy", tracy.module("tracy"));
     exe.linkLibrary(tracy.artifact("tracy"));

--- a/example/build.zig.zon
+++ b/example/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zig_tracy_example,
     .fingerprint = 0xe9dd79ab1e600c1e,
     .version = "0.0.2",
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.2",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/example/src/main.zig
+++ b/example/src/main.zig
@@ -3,7 +3,7 @@ const tracy = @import("tracy");
 
 var finalise_threads: std.Thread.ResetEvent = .{};
 
-fn handleSigInt(_: c_int) callconv(.C) void {
+export fn handleSigInt(_: c_int) void {
     finalise_threads.set();
 }
 
@@ -13,7 +13,7 @@ pub fn main() !void {
 
     std.posix.sigaction(std.posix.SIG.INT, &.{
         .handler = .{ .handler = handleSigInt },
-        .mask = std.posix.empty_sigset,
+        .mask = std.posix.sigemptyset(),
         .flags = 0,
     }, null);
 
@@ -25,7 +25,7 @@ pub fn main() !void {
 
         const zone = tracy.initZone(@src(), .{ .name = "Important work" });
         defer zone.deinit();
-        std.time.sleep(100);
+        std.Thread.sleep(100);
     }
 }
 
@@ -39,26 +39,31 @@ fn otherThread() void {
     defer arena.deinit();
 
     var tracing_allocator = tracy.TracingAllocator.initNamed("arena", arena.allocator());
+    const allocator = tracing_allocator.allocator();
 
-    var stack = std.ArrayList(u8).init(tracing_allocator.allocator());
-    defer stack.deinit();
+    var stack = std.ArrayList(u8).empty;
+    defer stack.deinit(allocator);
 
-    const stdin = std.io.getStdIn().reader();
-    const stdout = std.io.getStdOut().writer();
+    const stdin = std.fs.File.stdin().deprecatedReader();
+
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
 
     while (!finalise_threads.isSet()) {
         const zone = tracy.initZone(@src(), .{ .name = "IO loop" });
         defer zone.deinit();
 
         stdout.print("Enter string: ", .{}) catch break;
+        stdout.flush() catch break;
 
         const stream_zone = tracy.initZone(@src(), .{ .name = "Writer.streamUntilDelimiter" });
-        stdin.streamUntilDelimiter(stack.writer(), '\n', null) catch break;
+        stdin.streamUntilDelimiter(stack.writer(allocator), '\n', null) catch break;
         stream_zone.deinit();
 
         const toowned_zone = tracy.initZone(@src(), .{ .name = "ArrayList.toOwnedSlice" });
-        const str = stack.toOwnedSlice() catch break;
-        defer tracing_allocator.allocator().free(str);
+        const str = stack.toOwnedSlice(allocator) catch break;
+        defer allocator.free(str);
         toowned_zone.deinit();
 
         const reverse_zone = tracy.initZone(@src(), .{ .name = "std.mem.reverse" });

--- a/flake.lock
+++ b/flake.lock
@@ -1,35 +1,142 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691368598,
-        "narHash": "sha256-ia7li22keBBbj02tEdqjVeLtc7ZlSBuhUk+7XTUFr14=",
-        "path": "/nix/store/631cgbs310h1rcix7zs171xzx7p2y97g-source",
-        "rev": "5a8e9243812ba528000995b294292d3b5e120947",
-        "type": "path"
+        "lastModified": 1765425892,
+        "narHash": "sha256-jlQpSkg2sK6IJVzTQBDyRxQZgKADC2HKMRfGCSgNMHo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5d6bdbddb4695a62f0d00a3620b37a15275a5093",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
       }
     },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "zig-source": "zig-source"
-      }
-    },
-    "zig-source": {
-      "flake": false,
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712150963,
-        "narHash": "sha256-dMfSyQckPok5AyNeMWyJzSq6ow+K5GCoKiyt9tM1UdM=",
-        "type": "tarball",
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.3522%2Bb88ae8dbd.tar.xz"
+        "lastModified": 1708161998,
+        "narHash": "sha256-6KnemmUorCvlcAvGziFosAVkrlWZGIc6UNT9GUYr0jQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "84d981bae8b5e783b3b548de505b22880559515f",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.3522%2Bb88ae8dbd.tar.xz"
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "zig-overlay": "zig-overlay"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zig-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1764203689,
+        "narHash": "sha256-ivb0SqCptyIxx5g8ryRrUL0xrJhLrJPlvZbZjxVaui0=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "8f7347545dea59b75e40247cc1ed55a42f64dbbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,46 +2,32 @@
   description = "zig-tracy development environment";
 
   inputs = {
-    zig-source = {
-      url = "https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.3522+b88ae8dbd.tar.xz";
-      flake = false;
-    };
+    flake-utils.url = "github:numtide/flake-utils";
+    zig-overlay.url = "github:mitchellh/zig-overlay";
   };
 
   outputs = {
     self,
     nixpkgs,
-    zig-source
+    flake-utils,
+    zig-overlay
   }:
   let
-    default_system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${default_system};
-    zig_0_12_0_rc = pkgs.stdenv.mkDerivation rec {
-      pname = "zig";
-      version = "0.12.0-dev.3522+b88ae8dbd";
-      src = zig-source.outPath;
+    # https://github.com/mitchellh/zig-overlay/blob/a13f8e3f83ce51411d079579f28acb20472443f8/flake.nix#L21
+    systems = builtins.attrNames zig-overlay.packages;
+  in
+    flake-utils.lib.eachSystem systems (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        zigpkgs = zig-overlay.packages.${system};
+      in rec {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            zigpkgs."0.15.2"
 
-      installPhase = ''
-        mkdir -p "$out/bin"
-        cp zig "$out/bin"
-        cp -r lib "$out"
-        cp -r doc "$out"
-      '';
-
-      meta = with pkgs.lib; {
-        homepage = "https://ziglang.org/";
-        description = "General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software";
-        license = licenses.mit;
-        platforms = platforms.unix;
-      };
-    };
-  in {
-    devShell.${default_system} = pkgs.mkShell {
-      nativeBuildInputs = [
-        zig_0_12_0_rc
-        pkgs.lldb_16
-      ];
-    };
-  };
+            lldb
+          ];
+        };
+      }
+    );
 }
-


### PR DESCRIPTION
I updated the project to Zig 0.15.2 and updated the vastly outdated Nix Flakes files. I didn't set the version to 0.15.1 because [0.15.2 arguably introduces a breaking change](https://zsf.zulipchat.com/#narrow/channel/454371-std/topic/.E2.9C.94.20is.20takeDelimiterExclusive.20broken.3F/near/544413926).

For the example program, I changed the stdout writer to the new API but kept the stdin reader to the deprecated one, as the semantics of the example depends on it. It should be handled soon though, as the API has been [deleted](https://github.com/ziglang/zig/pull/25077) and will be gone by 0.16.0.

For Nix Flakes, I changed it to depend on https://github.com/mitchellh/zig-overlay to simplify the fetching of Zig binaries. This also comes with the added effect that it supports building for Aarch64, but I never tried Tracy on it so idek if that works. Whatever.